### PR TITLE
Adds basic support for the Stream Deck Mini

### DIFF
--- a/src/StreamDeck/StreamDeck.py
+++ b/src/StreamDeck/StreamDeck.py
@@ -427,11 +427,8 @@ class StreamDeckMini(StreamDeck):
         pages = (remaining_bytes // IMAGE_BYTES_FOLLOWUP_PAGES) + (leftovers != 0) # Full pages + leftover partial page if any
         last_slice_end = IMAGE_BYTES_FIRST_PAGE
 
-        #print( "\n\nGenerating reports.\n\nLengths: Payload={}, First={}, Followup={}, Final={}".format(len(image), IMAGE_BYTES_FIRST_PAGE, IMAGE_BYTES_FOLLOWUP_PAGES, (remaining_bytes % IMAGE_BYTES_FOLLOWUP_PAGES) ) )
-
         # Generate first report
         payload_first = bytes(header_1) + bytes(bmp_header) + image[: IMAGE_BYTES_FIRST_PAGE]
-        #print( "Payload {} length: {} | header {} + bytes 0 to {}\n".format(self.START_PAGE, len(payload_first), len(header_1)+len(bmp_header), IMAGE_BYTES_FIRST_PAGE) )
         self.device.write(payload_first)
 
         # Generate followup reports
@@ -446,6 +443,5 @@ class StreamDeckMini(StreamDeck):
                 payload_end = last_slice_end + IMAGE_BYTES_FOLLOWUP_PAGES
 
             payload_next = bytes(header_followup) + image[last_slice_end:payload_end]
-            #print("\n\nReport {} length: {} | header {} + bytes {} to {}".format(report_page, len(payload_next), len(header_followup), last_slice_end, payload_end))
             last_slice_end = payload_end
             self.device.write(payload_next)

--- a/src/StreamDeck/StreamDeck.py
+++ b/src/StreamDeck/StreamDeck.py
@@ -51,13 +51,13 @@ class DeviceManager(object):
         :rtype: list(StreamDeck)
         :return: list of :class:`StreamDeck` instances, one for each detected device.
         """
-		
+
         streamdeck_devices = self.transport.enumerate(
             vid=self.USB_VID_ELGATO, pid=self.USB_PID_STREAMDECK)
         streamdeckmini_devices = self.transport.enumerate(
             vid=self.USB_VID_ELGATO, pid=self.USB_PID_STREAMDECKMINI)
 
-        return ([StreamDeck(d) for d in streamdeck_devices],[StreamDeckMini(m) for m in streamdeckmini_devices])
+        return ([StreamDeck(d) for d in streamdeck_devices], [StreamDeckMini(m) for m in streamdeckmini_devices])
 
 
 class StreamDeck(object):
@@ -75,7 +75,7 @@ class StreamDeck(object):
     KEY_PIXEL_ORDER = "BGR"
 
     KEY_IMAGE_SIZE = KEY_PIXEL_WIDTH * KEY_PIXEL_HEIGHT * KEY_PIXEL_DEPTH
-	
+
     DECK_TYPE = "Stream Deck (Original)"
 
     def __init__(self, device):
@@ -353,16 +353,17 @@ class StreamDeck(object):
         """
         return self.last_key_states
 
+
 class StreamDeckMini(StreamDeck):
     """
     Represents a physically attached StreamDeck Mini device (USB_PID 0x0063).
-	
-	.. note:: The communication protocol for the Stream Deck Mini differs in 
-              several ways from that used by the original Stream Deck.  This 
-              currently prevents the button images on the mini from being updated, 
+
+    .. note:: The communication protocol for the Stream Deck Mini differs in
+              several ways from that used by the original Stream Deck.  This
+              currently prevents the button images on the mini from being updated,
               but this example will recognize the device and register keypresses.
     """
-	
+
     KEY_COUNT = 6
     KEY_COLS = 3
     KEY_ROWS = 2
@@ -373,8 +374,7 @@ class StreamDeckMini(StreamDeck):
     KEY_PIXEL_ORDER = "BGR"
 
     KEY_IMAGE_SIZE = KEY_PIXEL_WIDTH * KEY_PIXEL_HEIGHT * KEY_PIXEL_DEPTH
-	
     DECK_TYPE = "Stream Deck Mini"
-	
+
     def __init__(self, device):
         StreamDeck.__init__(self, device)

--- a/src/StreamDeck/StreamDeck.py
+++ b/src/StreamDeck/StreamDeck.py
@@ -407,7 +407,7 @@ class StreamDeckMini(StreamDeck):
 
         header_1 = [
             0x02, 0x01, self.START_PAGE, 0x00, 0x00, key + 1, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 
         bmp_header = [
             0x42, 0x4d, 0xf6, 0x3c, 0x00, 0x00, 0x00, 0x00,
@@ -416,7 +416,7 @@ class StreamDeckMini(StreamDeck):
             0x00, 0x00, 0x01, 0x00, 0x18, 0x00, 0x00, 0x00,
             0x00, 0x00, 0xc0, 0x3c, 0x00, 0x00, 0xc4, 0x0e,
             0x00, 0x00, 0xc4, 0x0e, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 
         # Lengths remaining after headers are added
         IMAGE_BYTES_FIRST_PAGE = self.REPORT_LENGTH - len(header_1) - len(bmp_header)
@@ -439,14 +439,14 @@ class StreamDeckMini(StreamDeck):
         last_slice_end = IMAGE_BYTES_FIRST_PAGE
 
         # Generate followup pages
-        for report_page in range(self.START_PAGE+1, pages):
+        for report_page in range(self.START_PAGE + 1, pages):
             # Byte 3 is page number, byte 5 indicates followup, byte 6 is keynumber to update
             header_followup = [
                 0x02, 0x01, report_page, 0x00, 0x01, key + 1, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 
             # Figure out where to stop pulling data from the image for this page
-            if (report_page == pages-1) and (leftovers != 0):
+            if (report_page == pages - 1) and (leftovers != 0):
                 payload_end = last_slice_end + leftovers
             else:
                 payload_end = last_slice_end + IMAGE_BYTES_FOLLOWUP_PAGES

--- a/src/StreamDeck/StreamDeck.py
+++ b/src/StreamDeck/StreamDeck.py
@@ -73,9 +73,13 @@ class StreamDeck(object):
     KEY_PIXEL_HEIGHT = 72
     KEY_PIXEL_DEPTH = 3
     KEY_PIXEL_ORDER = "BGR"
+    KEY_FLIPPED = True
+    KEY_ROTATION = 0
 
     KEY_IMAGE_SIZE = KEY_PIXEL_WIDTH * KEY_PIXEL_HEIGHT * KEY_PIXEL_DEPTH
 
+    START_PAGE = 1
+    REPORT_LENGTH = 8191
     DECK_TYPE = "Stream Deck (Original)"
 
     def __init__(self, device):
@@ -221,6 +225,8 @@ class StreamDeck(object):
             "height": self.KEY_PIXEL_HEIGHT,
             "depth": self.KEY_PIXEL_DEPTH,
             "order": self.KEY_PIXEL_ORDER,
+            "flip": self.KEY_FLIPPED,
+            "rotation": self.KEY_ROTATION,
         }
 
     def reset(self):
@@ -372,6 +378,8 @@ class StreamDeckMini(StreamDeck):
     KEY_PIXEL_HEIGHT = 80
     KEY_PIXEL_DEPTH = 3
     KEY_PIXEL_ORDER = "BGR"
+    KEY_FLIPPED = False
+    KEY_ROTATION = 90
 
     START_PAGE = 0          # Mini pages are 0 indexed, not 1
     REPORT_LENGTH = 1024    # Mini has a much smaller report size

--- a/src/StreamDeck/StreamDeck.py
+++ b/src/StreamDeck/StreamDeck.py
@@ -17,6 +17,7 @@ class DeviceManager(object):
 
     USB_VID_ELGATO = 0x0fd9
     USB_PID_STREAMDECK = 0x0060
+    USB_PID_STREAMDECKMINI = 0x0063
 
     @staticmethod
     def _get_transport(transport):
@@ -50,15 +51,18 @@ class DeviceManager(object):
         :rtype: list(StreamDeck)
         :return: list of :class:`StreamDeck` instances, one for each detected device.
         """
-
-        deck_devices = self.transport.enumerate(
+		
+        streamdeck_devices = self.transport.enumerate(
             vid=self.USB_VID_ELGATO, pid=self.USB_PID_STREAMDECK)
-        return [StreamDeck(d) for d in deck_devices]
+        streamdeckmini_devices = self.transport.enumerate(
+            vid=self.USB_VID_ELGATO, pid=self.USB_PID_STREAMDECKMINI)
+
+        return ([StreamDeck(d) for d in streamdeck_devices],[StreamDeckMini(m) for m in streamdeckmini_devices])
 
 
 class StreamDeck(object):
     """
-    Represents a physically attached StreamDeck device.
+    Represents a physically attached original StreamDeck device.  (USB_PID 0x0060)
     """
 
     KEY_COUNT = 15
@@ -71,6 +75,8 @@ class StreamDeck(object):
     KEY_PIXEL_ORDER = "BGR"
 
     KEY_IMAGE_SIZE = KEY_PIXEL_WIDTH * KEY_PIXEL_HEIGHT * KEY_PIXEL_DEPTH
+	
+    DECK_TYPE = "Stream Deck (Original)"
 
     def __init__(self, device):
         self.device = device
@@ -179,6 +185,15 @@ class StreamDeck(object):
         :return: Number of physical buttons.
         """
         return self.KEY_COUNT
+
+    def deck_type(self):
+        """
+        Retrieves the model of Stream Deck.
+
+        :rtype: str
+        :return: Text corresponding to the specific type of the device.
+        """
+        return self.DECK_TYPE
 
     def key_layout(self):
         """
@@ -337,3 +352,29 @@ class StreamDeck(object):
                  `False` otherwise).
         """
         return self.last_key_states
+
+class StreamDeckMini(StreamDeck):
+    """
+    Represents a physically attached StreamDeck Mini device (USB_PID 0x0063).
+	
+	.. note:: The communication protocol for the Stream Deck Mini differs in 
+              several ways from that used by the original Stream Deck.  This 
+              currently prevents the button images on the mini from being updated, 
+              but this example will recognize the device and register keypresses.
+    """
+	
+    KEY_COUNT = 6
+    KEY_COLS = 3
+    KEY_ROWS = 2
+
+    KEY_PIXEL_WIDTH = 72
+    KEY_PIXEL_HEIGHT = 72
+    KEY_PIXEL_DEPTH = 3
+    KEY_PIXEL_ORDER = "BGR"
+
+    KEY_IMAGE_SIZE = KEY_PIXEL_WIDTH * KEY_PIXEL_HEIGHT * KEY_PIXEL_DEPTH
+	
+    DECK_TYPE = "Stream Deck Mini"
+	
+    def __init__(self, device):
+        StreamDeck.__init__(self, device)

--- a/src/example.py
+++ b/src/example.py
@@ -53,8 +53,8 @@ def get_key_style(deck, key, state):
 
     if key == exit_key_index:
         name = "exit"
-        icon = "Assets/Exit.png"
-        text = "Exit"
+        icon = "Assets/{}.png".format("Exit" if state else "Exit") # Dummy condition for alt state
+        text = "Bye" if state else "Exit"
     else:
         name = "emoji"
         icon = "Assets/{}.png".format("Pressed" if state else "Released")
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     manager = StreamDeck.DeviceManager()
     streamdecks, minidecks = manager.enumerate()
 
-    print("Found {} Original Stream Decks and {} Stream Deck Minis.\n".format(len(streamdecks), len(minidecks)), flush=True)
+    print("Found {} Original Stream Deck(s) and {} Stream Deck Mini(s).\n".format(len(streamdecks), len(minidecks)), flush=True)
 
     decks = streamdecks + minidecks
 

--- a/src/example.py
+++ b/src/example.py
@@ -100,15 +100,21 @@ def key_change_callback(deck, key, state):
 
 if __name__ == "__main__":
     manager = StreamDeck.DeviceManager()
-    decks = manager.enumerate()
+    streamdecks, minidecks = manager.enumerate()
 
-    print("Found {} Stream Decks.".format(len(decks)), flush=True)
+    print("Found {} Original Stream Decks and {} Stream Deck Minis.\n".format(len(streamdecks), len(minidecks)), flush=True)
+
+    decks = streamdecks + minidecks
+
+    deck_count = 0
 
     for deck in decks:
         deck.open()
         deck.reset()
 
         deck.set_brightness(30)
+		
+        print("Deck at index {} has ID {}.\nIt is a {} with {} keys.\n".format(deck_count, deck.id(), deck.deck_type(), deck.key_count()), flush=True)
 
         # Set initial key images
         for key in range(deck.key_count()):
@@ -116,6 +122,8 @@ if __name__ == "__main__":
 
         # Register callback function for when a key state changes
         deck.set_key_callback(key_change_callback)
+
+        deck_count+=1
 
         # Wait until all application threads have terminated (for this example,
         # this is when all deck handles are closed)

--- a/src/example.py
+++ b/src/example.py
@@ -34,13 +34,12 @@ def render_key_image(width, height, rgb_order, icon_filename, label_text, flip, 
         # StreamDeck Mini sends images in a different orientation than the original.
         image = image.rotate(90)
 
-    #Get the raw r, g and b components of the generated image 
+    # Get the raw r, g and b components of the generated image
     if flip:
         # Flip image horizontally to match the format the (original) StreamDeck expects
         r, g, b = image.transpose(Image.FLIP_LEFT_RIGHT).split()
     else:
         r, g, b = image.split()
-
 
     # Recombine the B, G and R elements in the order the display expects them,
     # and convert the resulting image to a sequence of bytes

--- a/src/example.py
+++ b/src/example.py
@@ -53,7 +53,7 @@ def get_key_style(deck, key, state):
 
     if key == exit_key_index:
         name = "exit"
-        icon = "Assets/{}.png".format("Exit" if state else "Exit") # Dummy condition for alt state
+        icon = "Assets/{}.png".format("Exit" if state else "Exit")  # Dummy condition for alt state
         text = "Bye" if state else "Exit"
     else:
         name = "emoji"
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         # Diagnostic output
         print("Deck at index {} has ID {}.\nIt is a {} with {} keys.".format(deck_count, deck.id(), deck.deck_type(), deck.key_count()), flush=True)
         print("Acceptable image upload format for this device is {}x{} pixels with a depth of {}, in {} order.".format(deck.key_image_format()['width'], deck.key_image_format()['height'], deck.key_image_format()['depth'], deck.key_image_format()['order']))
-        rotating = ", but will rotate them by {} degrees".format(deck.key_image_format()['rotation']) if deck.key_image_format()['rotation']!=0 else ""
+        rotating = ", but will rotate them by {} degrees".format(deck.key_image_format()['rotation']) if deck.key_image_format()['rotation'] != 0 else ""
         flipverb = "will" if deck.key_image_format()['flip'] else "will not"
         print("Device expects that software {} flip the images before uploading{}.\n".format(flipverb, rotating))
 

--- a/src/example.py
+++ b/src/example.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         deck.reset()
 
         deck.set_brightness(30)
-		
+
         print("Deck at index {} has ID {}.\nIt is a {} with {} keys.\n".format(deck_count, deck.id(), deck.deck_type(), deck.key_count()), flush=True)
 
         # Set initial key images
@@ -123,7 +123,7 @@ if __name__ == "__main__":
         # Register callback function for when a key state changes
         deck.set_key_callback(key_change_callback)
 
-        deck_count+=1
+        deck_count += 1
 
         # Wait until all application threads have terminated (for this example,
         # this is when all deck handles are closed)


### PR DESCRIPTION
The Streamdeck mini has a different USB PID (and obviously number of
buttons and layout) than the original Streamdeck.  The changes here
enable basic device recognition and keypress detection.  Due to some
underlying protocol changes, updating the button images doesn't
currently work on the Mini at all.  ([Issue 56 on the github for the node.js equivalent](https://github.com/Lange/node-elgato-stream-deck/issues/56)
has some discussion of the details.)

StreadDeckMini is implemented as a subclass of StreamDeck.  Instead of
just a single list, DeviceManager.enumerate() now returns a tuple
consisting of a list of original StreamDeck objects and a list of
StreamDeckMini objects, which is probably not the most efficient way to
do it, but it works.

Note: I don't think anything here will break Original StreamDeck functionality, 
but I am unable to test that since I don't have one.