### PR TITLE
Add alternative HID backend, transport autoprobing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,6 @@ front-ends, such as a custom control front-end for home automation software.
 
 [Online Documentation](https://python-elgato-streamdeck.readthedocs.io)
 
-## Credits:
-
-I've used the reverse engineering notes from
-[this GitHub](https://github.com/Lange/node-elgato-stream-deck/blob/master/NOTES.md)
-repository to implement this library. Thanks Alex Van Camp!
-
-Initial StreamDeck Mini support added by [Aetherdyne](https://github.com/Aetherdyne).
-
-StreamDeck XL support assisted by [Pointshader](https://github.com/pointshader).
-
 ## Status:
 
 Working - you can enumerate devices, set the brightness of the panel(s), set
@@ -31,24 +21,43 @@ Currently the following StreamDeck product variants are supported:
 * StreamDeck Mini
 * StreamDeck XL
 
-## Dependencies:
+## Package Dependencies:
 
 The library core has no special dependencies, but does use one of (potentially)
 several HID backend libraries. You will need to install the dependencies
 appropriate to your chosen backend.
 
-The included example requires the PIL fork "Pillow", although it can be swapped
+The included examples require the PIL fork "Pillow", although it can be swapped
 out if desired by the user application for any other image manipulation library.
 
-To install all library dependencies at once, run:
-```
-pip install -r requirements.txt
-```
+### HID Backend
+
+The recommended HID backend is the aptly named
+[HID Python library](https://pypi.org/project/hid/), which should work across
+the three major (Windows, Mac, Linux) OSes and is the most up-to-date. This can
+be installed via `pip3 install hid`.
+
+Note that Windows systems requires additional manual installation of a DLL in
+order to function. The latest source for this DLL is the
+[libUSB GitHub project](https://github.com/libusb/hidapi/releases).
+
+Despite the additional setup, this will give the best results in terms of
+reliability and performance.
 
 ### HIDAPI Backend
 
-The default backend is the HIDAPI Python library, which should work across
-the three major (Windows, Mac, Linux) OSes.
+Another option is the older
+[HIDAPI Python library](https://pypi.org/project/hidapi/), which originates from
+the same original project as the HID library listed above, but is now entirely
+unmaintained. This can be installed via `pip3 install hidapi`.
+
+Several users report issues with this backend due to various bugs
+that have not been patched in the packaged library version, but support for it
+is included in this library due to its simple one-line setup on all three major
+platforms.
+
+Note the library package name conflicts with the HID backend above; only one or
+the other should be installed at the same time.
 
 ## Package Installation:
 
@@ -81,6 +90,7 @@ sudo apt install -y libudev-dev libusb-1.0-0-dev
 
 # Install dependencies
 pip3 install hidapi
+pip3 install pillow
 
 # Add udev rule to allow all users non-root access to Elgato StreamDeck devices:
 sudo tee /etc/udev/rules.d/10-streamdeck.rules << EOF
@@ -98,6 +108,26 @@ pip3 install streamdeck
 Note that after adding the `udev` rule, a restart will be required in order for
 it to take effect and allow access to the StreamDeck device without requiring
 root privileges.
+
+## Credits:
+
+I've used the reverse engineering notes from
+[this GitHub](https://github.com/Lange/node-elgato-stream-deck/blob/master/NOTES.md)
+repository to implement this library. Thanks Alex Van Camp!
+
+Thank you to the following contributors, large and small, for helping with the
+development and maintenance of this library:
+
+- [Aetherdyne](https://github.com/Aetherdyne)
+- [dirkk0](https://github.com/dirkk0)
+- [Kalle-Wirsch](https://github.com/Kalle-Wirsch)
+- [pointshader](https://github.com/pointshader)
+- [spidererrol](https://github.com/Spidererrol)
+- [Subsentient](https://github.com/Subsentient)
+- [shanna](https://github.com/shanna)
+
+If you've contributed in some manner, but I've accidentally missed you in the
+list above, please let me know.
 
 ## License:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==1.8.4
+Sphinx==2.2.0
 sphinx-rtd-theme==0.4.3
 m2r==0.2.1

--- a/doc/source/modules/transports.rst
+++ b/doc/source/modules/transports.rst
@@ -5,6 +5,10 @@ Modules: Communication Transports
 .. automodule:: StreamDeck.Transport.Transport
    :members:
 
+.. automodule:: StreamDeck.Transport.HID
+   :members:
+   :show-inheritance:
+
 .. automodule:: StreamDeck.Transport.HIDAPI
    :members:
    :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-hidapi==0.7.99.post21
 Pillow>=5.0.0

--- a/src/StreamDeck/Transport/Dummy.py
+++ b/src/StreamDeck/Transport/Dummy.py
@@ -38,7 +38,7 @@ class Dummy(Transport):
 
         def read_feature(self, report_id, length):
             logging.info('Deck feature read (length %s)', length)
-            raise Exception("Dummy device!")
+            raise IOError("Dummy device!")
 
         def write(self, payload):
             logging.info('Deck report write (length %s): %s', len(payload), binascii.hexlify(payload))
@@ -46,11 +46,11 @@ class Dummy(Transport):
 
         def read(self, length):
             logging.info('Deck report read (length %s)', length)
-            raise Exception("Dummy device!")
-
-    def enumerate(self, vid, pid):
-        return [Dummy.Device("{}:{}".format(vid, pid))]
+            raise IOError("Dummy device!")
 
     @staticmethod
     def probe():
         pass
+
+    def enumerate(self, vid, pid):
+        return [Dummy.Device("{}:{}".format(vid, pid))]

--- a/src/StreamDeck/Transport/Dummy.py
+++ b/src/StreamDeck/Transport/Dummy.py
@@ -38,7 +38,7 @@ class Dummy(Transport):
 
         def read_feature(self, report_id, length):
             logging.info('Deck feature read (length %s)', length)
-            raise IOError("Dummy device!")
+            raise Exception("Dummy device!")
 
         def write(self, payload):
             logging.info('Deck report write (length %s): %s', len(payload), binascii.hexlify(payload))
@@ -46,11 +46,11 @@ class Dummy(Transport):
 
         def read(self, length):
             logging.info('Deck report read (length %s)', length)
-            raise IOError("Dummy device!")
+            raise Exception("Dummy device!")
 
     def enumerate(self, vid, pid):
         return [Dummy.Device("{}:{}".format(vid, pid))]
 
     @staticmethod
     def probe():
-        return False
+        pass

--- a/src/StreamDeck/Transport/Dummy.py
+++ b/src/StreamDeck/Transport/Dummy.py
@@ -38,7 +38,7 @@ class Dummy(Transport):
 
         def read_feature(self, report_id, length):
             logging.info('Deck feature read (length %s)', length)
-            return IOError("Dummy device!")
+            raise IOError("Dummy device!")
 
         def write(self, payload):
             logging.info('Deck report write (length %s): %s', len(payload), binascii.hexlify(payload))
@@ -50,3 +50,7 @@ class Dummy(Transport):
 
     def enumerate(self, vid, pid):
         return [Dummy.Device("{}:{}".format(vid, pid))]
+
+    @staticmethod
+    def probe():
+        return False

--- a/src/StreamDeck/Transport/HID.py
+++ b/src/StreamDeck/Transport/HID.py
@@ -146,6 +146,17 @@ class HID(Transport):
             """
             return self.hid.read(length)
 
+    @staticmethod
+    def probe():
+        """
+        Attempts to determine if the back-end is installed and usable. It is
+        expected that probe failures throw exceptions detailing their exact
+        cause of failure.
+        """
+
+        import hid
+        hid.enumerate(vid=0, pid=0)
+
     def enumerate(self, vid, pid):
         """
         Enumerates all available USB HID devices on the system.
@@ -169,12 +180,3 @@ class HID(Transport):
         devices = hid.enumerate(vid=vid, pid=pid)
 
         return [HID.Device(d) for d in devices]
-
-    @staticmethod
-    def probe():
-        """
-        Attempts to determine if the back-end is installed and usable.
-        """
-
-        import hid
-        hid.enumerate(vid=0, pid=0)

--- a/src/StreamDeck/Transport/HID.py
+++ b/src/StreamDeck/Transport/HID.py
@@ -173,17 +173,8 @@ class HID(Transport):
     @staticmethod
     def probe():
         """
-        Attempts to determine if the backend is installed and usable.
-
-        :rtype: bool
-        :return: True if the backend is installed and is likely usable to
-                 discover and communicate with attached devices.
+        Attempts to determine if the back-end is installed and usable.
         """
-        try:
-            import hid
 
-            hid.enumerate(vid=0, pid=0)
-
-            return True
-        except:  # noqa: E722
-            return False
+        import hid
+        hid.enumerate(vid=0, pid=0)

--- a/src/StreamDeck/Transport/HIDAPI.py
+++ b/src/StreamDeck/Transport/HIDAPI.py
@@ -165,17 +165,8 @@ class HIDAPI(Transport):
     @staticmethod
     def probe():
         """
-        Attempts to determine if the backend is installed and usable.
-
-        :rtype: bool
-        :return: True if the backend is installed and is likely usable to
-                 discover and communicate with attached devices.
+        Attempts to determine if the back-end is installed and usable.
         """
-        try:
-            import hid
 
-            hid.enumerate(vendor_id=0, product_id=0)
-
-            return True
-        except:  # noqa: E722
-            return False
+        import hid
+        hid.enumerate(vid=0, pid=0)

--- a/src/StreamDeck/Transport/HIDAPI.py
+++ b/src/StreamDeck/Transport/HIDAPI.py
@@ -138,6 +138,17 @@ class HIDAPI(Transport):
             """
             return self.hid.read(length)
 
+    @staticmethod
+    def probe():
+        """
+        Attempts to determine if the back-end is installed and usable. It is
+        expected that probe failures throw exceptions detailing their exact
+        cause of failure.
+        """
+
+        import hid
+        hid.enumerate(vid=0, pid=0)
+
     def enumerate(self, vid, pid):
         """
         Enumerates all available USB HID devices on the system.
@@ -161,12 +172,3 @@ class HIDAPI(Transport):
         devices = hid.enumerate(vendor_id=vid, product_id=pid)
 
         return [HIDAPI.Device(d) for d in devices]
-
-    @staticmethod
-    def probe():
-        """
-        Attempts to determine if the back-end is installed and usable.
-        """
-
-        import hid
-        hid.enumerate(vid=0, pid=0)

--- a/src/StreamDeck/Transport/Transport.py
+++ b/src/StreamDeck/Transport/Transport.py
@@ -126,11 +126,9 @@ class Transport(ABC):
     @abstractmethod
     def probe():
         """
-        Attempts to determine if the backend is installed and usable.
-
-        :rtype: bool
-        :return: True if the backend is installed and is likely usable to
-                 discover and communicate with attached devices.
+        Attempts to determine if the back-end is installed and usable. It is
+        expected that probe failures throw exceptions detailing their exact
+        cause of failure.
         """
         pass
 

--- a/src/StreamDeck/Transport/Transport.py
+++ b/src/StreamDeck/Transport/Transport.py
@@ -124,6 +124,17 @@ class Transport(ABC):
             pass
 
     @abstractmethod
+    def probe():
+        """
+        Attempts to determine if the backend is installed and usable.
+
+        :rtype: bool
+        :return: True if the backend is installed and is likely usable to
+                 discover and communicate with attached devices.
+        """
+        pass
+
+    @abstractmethod
     def enumerate(self, vid, pid):
         """
         Enumerates all available devices on the system using the current


### PR DESCRIPTION
Open RFC - looking for feedback and testing before merge.

This is an alternative HID backend for the library, using the newer and maintained `hid` library (based off the patch in #15 by @Subsentient, cleaned up). I originally selected the `hidapi` library as it doesn't require any special setup on Windows (it bundles an old version of the DLL) but the various instability reports are making me think this was a bad choice. The `hid` library needs manual installation of a DLL on Windows, but at least is maintained and contains some critical bugfixes.

In this patch I've altered the main StreamDeck manager code to by default try to autoprobe which backends are available - this way, as long as one of them are installed it should "just work".

@Aetherdyne, this should also fix #18 for you.