### PR TITLE
Fix memory leak caused by class scope typo

### DIFF
--- a/src/StreamDeck/DeviceManager.py
+++ b/src/StreamDeck/DeviceManager.py
@@ -103,7 +103,7 @@ class DeviceManager:
         ]
 
         streamdecks = list()
-
+        
         for vid, pid, class_type in products:
             found_devices = self.transport.enumerate(vid=vid, pid=pid)
             streamdecks.extend([class_type(d) for d in found_devices])

--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
+++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
@@ -34,10 +34,10 @@ class LibUSBHIDAPI(Transport):
 
             if self.HIDAPI_INSTANCE:
                 return self.HIDAPI_INSTANCE
-
+            
             for lib_name in library_search_list:
                 try:
-                    self.HIDAPI_INSTANCE = ctypes.cdll.LoadLibrary(lib_name)
+                    LibUSBHIDAPI.Library.HIDAPI_INSTANCE = ctypes.cdll.LoadLibrary(lib_name)
                     break
                 except OSError:
                     pass
@@ -314,6 +314,9 @@ class LibUSBHIDAPI(Transport):
             """
             self.close()
 
+        def __del__(self):
+            self.__exit__()
+    
         def open(self):
             """
             Opens the HID device for input/output. This must be called prior to
@@ -323,7 +326,7 @@ class LibUSBHIDAPI(Transport):
                          close method.
             """
             if self.device_handle:
-                self.close()
+                return
 
             self.device_handle = self.hidapi.open_device(self.device_info['path'])
 
@@ -439,5 +442,5 @@ class LibUSBHIDAPI(Transport):
         """
 
         hidapi = LibUSBHIDAPI.Library()
-
+        
         return [LibUSBHIDAPI.Device(hidapi, d) for d in hidapi.enumerate(vendor_id=vid, product_id=pid)]


### PR DESCRIPTION
This causes a particularly nasty leak over time, enough to trigger the OOM killer, and happens on Windows and Linux at least.