### PR TITLE
Load scaled image

### DIFF
--- a/src/StreamDeck/ImageHelpers/PILHelper.py
+++ b/src/StreamDeck/ImageHelpers/PILHelper.py
@@ -29,6 +29,7 @@ def create_image(deck, background='black'):
 
     return Image.new("RGB", image_format['size'], background)
 
+
 def load_scaled_image(deck, image_path, background='black'):
     """
     Loads an image from image_path and scales it to fit the given StreamDeck
@@ -41,7 +42,9 @@ def load_scaled_image(deck, image_path, background='black'):
     :rtrype: PIL.Image
     :return: Loaded PIL image scaled and centered
     """
-    image = PILHelper.create_image(deck, background=background)
+    from PIL import Image
+
+    image = create_image(deck, background=background)
 
     # Resize the source image asset to best-fit the dimensions of a single key,
     # and paste it onto our blank frame centered as closely as possible.
@@ -51,6 +54,7 @@ def load_scaled_image(deck, image_path, background='black'):
     image.paste(icon, icon_pos, icon)
 
     return image
+
 
 def to_native_format(deck, image):
     """

--- a/src/StreamDeck/ImageHelpers/PILHelper.py
+++ b/src/StreamDeck/ImageHelpers/PILHelper.py
@@ -29,6 +29,28 @@ def create_image(deck, background='black'):
 
     return Image.new("RGB", image_format['size'], background)
 
+def load_scaled_image(deck, image_path, background='black'):
+    """
+    Loads an image from image_path and scales it to fit the given StreamDeck
+    device's keys, and centers it.
+
+    .. seealso:: See :func:`~PILHelper.to_native_format` method for converting a
+                 PIL image instance to the native image format of a given
+                 StreamDeck device
+
+    :rtrype: PIL.Image
+    :return: Loaded PIL image scaled and centered
+    """
+    image = PILHelper.create_image(deck, background=background)
+
+    # Resize the source image asset to best-fit the dimensions of a single key,
+    # and paste it onto our blank frame centered as closely as possible.
+    icon = Image.open(image_path).convert("RGBA")
+    icon.thumbnail((image.width, image.height), Image.LANCZOS)
+    icon_pos = ((image.width - icon.width) // 2, (image.height - icon.height) // 2)
+    image.paste(icon, icon_pos, icon)
+
+    return image
 
 def to_native_format(deck, image):
     """

--- a/src/example_basic.py
+++ b/src/example_basic.py
@@ -13,7 +13,7 @@
 import os
 import threading
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import ImageDraw, ImageFont
 from StreamDeck.DeviceManager import DeviceManager
 from StreamDeck.ImageHelpers import PILHelper
 

--- a/src/example_basic.py
+++ b/src/example_basic.py
@@ -24,15 +24,9 @@ ASSETS_PATH = os.path.join(os.path.dirname(__file__), "Assets")
 # Generates a custom tile with run-time generated text and custom image via the
 # PIL module.
 def render_key_image(deck, icon_filename, font_filename, label_text):
-    # Create new key image of the correct dimensions, black background.
-    image = PILHelper.create_image(deck)
-
     # Resize the source image asset to best-fit the dimensions of a single key,
     # and paste it onto our blank frame centered as closely as possible.
-    icon = Image.open(icon_filename).convert("RGBA")
-    icon.thumbnail((image.width, image.height - 20), Image.LANCZOS)
-    icon_pos = ((image.width - icon.width) // 2, 0)
-    image.paste(icon, icon_pos, icon)
+    image = PILHelper.load_scaled_image(deck, icon_filename)
 
     # Load a custom TrueType font and use it to overlay the key index, draw key
     # label onto the image.

--- a/src/test.py
+++ b/src/test.py
@@ -8,9 +8,12 @@
 #
 
 import logging
+import os
 
 from StreamDeck.DeviceManager import DeviceManager
 from StreamDeck.ImageHelpers import PILHelper
+
+ASSETS_PATH = os.path.join(os.path.dirname(__file__), "Assets")
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
@@ -36,6 +39,9 @@ if __name__ == "__main__":
 
             test_key_image = PILHelper.create_image(deck)
             test_key_image = PILHelper.to_native_format(deck, test_key_image)
+
+            scaled_image_path = os.path.join(ASSETS_PATH, "Pressed.png")
+            test_scaled_image = PILHelper.load_scaled_image(deck, scaled_image_path)
 
             deck.set_key_callback(None)
             deck.reset()


### PR DESCRIPTION
This pull request adds a small utility function to the PILHelper module, which is based on one of the examples in example_basic.py -- all it does is scale and center the image.

I read through your notes on issue #24 regarding library bloat. However, I believe this fits within the spirit of your sentiment there and is a sufficiently common need for almost any application that it makes sense to bundle it.

This returns a PIL format image so that users of various applications can easily continue to render (e.g., by adding text or whatnot). I updated example_basic.py to reflect this exact usage, effectively refactoring that chunk of code into PILHelper.