### PR TITLE
Close device if read thread detects failure.

### DIFF
--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -119,6 +119,7 @@ class StreamDeck(ABC):
                 self.last_key_states = new_key_states
             except (TransportError):
                 self.run_read_thread = False
+                self.close()
 
     def _setup_reader(self, callback):
         """
@@ -165,7 +166,7 @@ class StreamDeck(ABC):
 
     def is_open(self):
         """
-        Indicattes if the StreamDeck device is currently open and ready for use..
+        Indicates if the StreamDeck device is currently open and ready for use.
 
         :rtype: bool
         :return: `True` if the deck is open, `False` otherwise.


### PR DESCRIPTION
@abcminiuser Thanks for adding the `is_open()` method. I had a look and I believe the only thing that is missing right now to properly detect a suspend is that the `close()` method needs to be called if the *internal read thread* detects failure.

A library user can call `close()` from the outside if any other read or write operation fails. However, a failure on the background the read thread goes undetected.

I tested it and can now successfully detect a suspend and recover from it.