### PR TITLE
Each button needs its own cycle

### DIFF
--- a/src/example_animated.py
+++ b/src/example_animated.py
@@ -85,10 +85,10 @@ if __name__ == "__main__":
         # Pre-render a list of animation frames for each source image, in the
         # native display format so that they can be quickly sent to the device.
         print("Loading animations...")
-        animations = [
-            create_animation_frames(deck, "Elephant_Walking_animated.gif"),
-            create_animation_frames(deck, "RGB_color_space_animated_view.gif"),
-            create_animation_frames(deck, "Simple_CV_Joint_animated.gif"),
+        gifs = [
+            "Elephant_Walking_animated.gif",
+            "RGB_color_space_animated_view.gif",
+            "Simple_CV_Joint_animated.gif"
         ]
         print("Ready.")
 
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         # be displayed.
         key_images = dict()
         for k in range(deck.key_count()):
-            key_images[k] = animations[k % len(animations)]
+            key_images[k] = create_animation_frames(deck, gifs[k % len(gifs)])
 
         # Helper function that will run a periodic loop which updates the
         # images on each key.

--- a/src/example_animated.py
+++ b/src/example_animated.py
@@ -90,13 +90,14 @@ if __name__ == "__main__":
             "RGB_color_space_animated_view.gif",
             "Simple_CV_Joint_animated.gif"
         ]
-        print("Ready.")
 
         # Create a mapping of StreamDeck keys to animation image sets that will
         # be displayed.
         key_images = dict()
         for k in range(deck.key_count()):
             key_images[k] = create_animation_frames(deck, gifs[k % len(gifs)])
+
+        print("Ready.")
 
         # Helper function that will run a periodic loop which updates the
         # images on each key.


### PR DESCRIPTION
Love this library so far!  I noticed in the example for animated buttons the animations looked way too fast and didn't seem to jive with the original gifs at all.  I figured out that the re-use of the cycle created by the `create_animation_frames()` function was only getting shallow copied into the `key_images` list.  This resulted in all buttons with the same image getting incremented with every `next()` call which I don't think was the intent.  By creating separate cycles for every button this is solved and all the gifs look great now.  The side effect is the initial load takes a bit longer but I think it makes more sense.  I tried applying a `copy.deepcopy` but that wouldn't work for either the cycles or the images.