### PR TITLE
StreamDeckPedal: initial support

### DIFF
--- a/doc/source/examples/pedal.rst
+++ b/doc/source/examples/pedal.rst
@@ -1,0 +1,8 @@
+*********************
+Example Script: Pedal
+*********************
+
+The following is an example script to connect to the Stream Deck Pedal, and print whenever its buttons are pushed and released.
+
+.. literalinclude:: ../../../src/example_pedal.py
+    :language: python

--- a/src/StreamDeck/DeviceManager.py
+++ b/src/StreamDeck/DeviceManager.py
@@ -9,6 +9,7 @@ from .Devices.StreamDeckMini import StreamDeckMini
 from .Devices.StreamDeckOriginal import StreamDeckOriginal
 from .Devices.StreamDeckOriginalV2 import StreamDeckOriginalV2
 from .Devices.StreamDeckXL import StreamDeckXL
+from .Devices.StreamDeckPedal import StreamDeckPedal
 from .Transport.Dummy import Dummy
 from .Transport.LibUSBHIDAPI import LibUSBHIDAPI
 
@@ -35,6 +36,7 @@ class DeviceManager:
     USB_PID_STREAMDECK_MINI = 0x0063
     USB_PID_STREAMDECK_XL = 0x006c
     USB_PID_STREAMDECK_MK2 = 0x0080
+    USB_PID_STREAMDECK_PEDAL = 0x0086
 
     @staticmethod
     def _get_transport(transport):
@@ -102,6 +104,7 @@ class DeviceManager:
             (self.USB_VID_ELGATO, self.USB_PID_STREAMDECK_MINI, StreamDeckMini),
             (self.USB_VID_ELGATO, self.USB_PID_STREAMDECK_XL, StreamDeckXL),
             (self.USB_VID_ELGATO, self.USB_PID_STREAMDECK_MK2, StreamDeckOriginalV2),
+            (self.USB_VID_ELGATO, self.USB_PID_STREAMDECK_PEDAL, StreamDeckPedal),
         ]
 
         streamdecks = list()

--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -305,6 +305,12 @@ class StreamDeck(ABC):
                  otherwise).
         """
         return self.last_key_states
+    
+    def is_visual(self):
+        """
+        Returns whether the Stream Deck has a visual display.
+        """
+        return True
 
     @abstractmethod
     def reset(self):

--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -305,7 +305,7 @@ class StreamDeck(ABC):
                  otherwise).
         """
         return self.last_key_states
-    
+
     def is_visual(self):
         """
         Returns whether the Stream Deck has a visual display.

--- a/src/StreamDeck/Devices/StreamDeckPedal.py
+++ b/src/StreamDeck/Devices/StreamDeckPedal.py
@@ -1,0 +1,100 @@
+#         Python Stream Deck Library
+#      Released under the MIT license
+#
+#   dean [at] fourwalledcubicle [dot] com
+#         www.fourwalledcubicle.com
+#
+
+from .StreamDeck import StreamDeck
+
+
+class StreamDeckPedal(StreamDeck):
+    """
+    Represents a physically attached StreamDeck Pedal device.
+    """
+
+    KEY_COUNT = 3
+    KEY_COLS = 3
+    KEY_ROWS = 1
+
+    DECK_TYPE = "Stream Deck Pedal"
+
+    def _read_key_states(self):
+        """
+        Reads the key states of the StreamDeck. This is used internally by
+        :func:`~StreamDeck._read` to talk to the actual device.
+
+        :rtype: list(bool)
+        :return: Button states, with the origin at the top-left of the deck.
+        """
+
+        states = self.device.read(4 + self.KEY_COUNT)
+        if states is None:
+            return None
+
+        states = states[4:]
+        return [bool(s) for s in states]
+
+    def _reset_key_stream(self):
+        """
+        Sends a blank key report to the StreamDeck, resetting the key image
+        streamer in the device. This prevents previously started partial key
+        writes that were not completed from corrupting images sent from this
+        application.
+        """
+        pass
+
+    def reset(self):
+        """
+        Resets the StreamDeck, clearing all button images and showing the
+        standby image.
+        """
+        pass
+
+    def set_brightness(self, percent):
+        """
+        Sets the global screen brightness of the StreamDeck, across all the
+        physical buttons.
+
+        :param int/float percent: brightness percent, from [0-100] as an `int`,
+                                  or normalized to [0.0-1.0] as a `float`.
+        """
+        pass
+
+    def get_serial_number(self):
+        serial = self.device.read_feature(0x06, 32)
+        return self._extract_string(serial[2:])
+
+    def get_firmware_version(self):
+        """
+        Gets the firmware version of the attached StreamDeck.
+
+        :rtype: str
+        :return: String containing the firmware version of the attached device.
+        """
+
+        version = self.device.read_feature(0x05, 32)
+        return self._extract_string(version[6:])
+    
+    def is_visual(self):
+        """
+        Returns whether the Stream Deck has a visual display.
+        """
+        return False
+
+
+    def set_key_image(self, key, image):
+        """
+        Sets the image of a button on the StreamDeck to the given image. The
+        image being set should be in the correct format for the device, as an
+        enumerable collection of bytes.
+
+        .. seealso:: See :func:`~StreamDeck.get_key_image_format` method for
+                     information on the image format accepted by the device.
+
+        :param int key: Index of the button whose image is to be updated.
+        :param enumerable image: Raw data of the image to set on the button.
+                                 If `None`, the key will be cleared to a black
+                                 color.
+        """
+        pass

--- a/src/StreamDeck/Devices/StreamDeckPedal.py
+++ b/src/StreamDeck/Devices/StreamDeckPedal.py
@@ -75,13 +75,12 @@ class StreamDeckPedal(StreamDeck):
 
         version = self.device.read_feature(0x05, 32)
         return self._extract_string(version[6:])
-    
+
     def is_visual(self):
         """
         Returns whether the Stream Deck has a visual display.
         """
         return False
-
 
     def set_key_image(self, key, image):
         """

--- a/src/example_basic.py
+++ b/src/example_basic.py
@@ -112,14 +112,14 @@ if __name__ == "__main__":
     for index, deck in enumerate(streamdecks):
         if not deck.is_visual():
             continue
-        
+
         deck.open()
         deck.reset()
 
         print("Opened '{}' device (serial number: '{}', fw: '{}')".format(
             deck.deck_type(), deck.get_serial_number(), deck.get_firmware_version()
         ))
-        
+
         # Set initial screen brightness to 30%.
         deck.set_brightness(30)
 

--- a/src/example_basic.py
+++ b/src/example_basic.py
@@ -110,11 +110,16 @@ if __name__ == "__main__":
     print("Found {} Stream Deck(s).\n".format(len(streamdecks)))
 
     for index, deck in enumerate(streamdecks):
+        if not deck.is_visual():
+            continue
+        
         deck.open()
         deck.reset()
 
-        print("Opened '{}' device (serial number: '{}')".format(deck.deck_type(), deck.get_serial_number()))
-
+        print("Opened '{}' device (serial number: '{}', fw: '{}')".format(
+            deck.deck_type(), deck.get_serial_number(), deck.get_firmware_version()
+        ))
+        
         # Set initial screen brightness to 30%.
         deck.set_brightness(30)
 

--- a/src/example_pedal.py
+++ b/src/example_pedal.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+#         Python Stream Deck Library
+#      Released under the MIT license
+#
+#   dean [at] fourwalledcubicle [dot] com
+#         www.fourwalledcubicle.com
+#
+
+# Example script showing basic library usage - updating key images with new
+# tiles generated at runtime, and responding to button state change events.
+
+import threading
+
+from StreamDeck.DeviceManager import DeviceManager
+
+
+def key_change_callback(deck, key, state):
+    print("Deck {} Key {} = {}".format(deck.id(), key, "down" if state else "up"), flush=True)
+
+
+if __name__ == "__main__":
+    streamdecks = DeviceManager().enumerate()
+
+    print("Found {} Stream Deck(s).\n".format(len(streamdecks)))
+
+    for index, deck in enumerate(streamdecks):
+        if deck.deck_type() != 'Stream Deck Pedal':
+            continue
+
+        deck.open()
+
+        print("Opened '{}' device (serial number: '{}', fw: '{}')".format(
+            deck.deck_type(), deck.get_serial_number(), deck.get_firmware_version()
+        ))
+
+        # Register callback function for when a key state changes.
+        deck.set_key_callback(key_change_callback)
+
+        # Wait until all application threads have terminated (for this example,
+        # this is when all deck handles are closed).
+        for t in threading.enumerate():
+            try:
+                t.join()
+            except RuntimeError:
+                pass

--- a/src/test.py
+++ b/src/test.py
@@ -17,6 +17,8 @@ from PIL import Image, ImageDraw
 
 
 def test_pil_helpers(deck):
+    if not deck.is_visual():
+        return
     test_scaled_image = PILHelper.create_scaled_image(deck, Image.new("RGB", (1, 1)))     # noqa: F841
 
     test_key_image = PILHelper.create_image(deck)
@@ -32,23 +34,28 @@ def test_basic_apis(deck):
         key_count = deck.key_count()     # noqa: F841
         deck_type = deck.deck_type()     # noqa: F841
         key_layout = deck.key_layout()     # noqa: F841
-        image_format = deck.key_image_format()     # noqa: F841
+        if deck.is_visual():
+            image_format = deck.key_image_format()     # noqa: F841
         key_states = deck.key_states()     # noqa: F841
 
         deck.set_key_callback(None)
         deck.reset()
-        deck.set_brightness(30)
 
-        test_key_image = PILHelper.create_image(deck)
-        test_key_image = PILHelper.to_native_format(deck, test_key_image)
+        if deck.is_visual():
+            deck.set_brightness(30)
 
-        deck.set_key_image(0, None)
-        deck.set_key_image(0, test_key_image)
+            test_key_image = PILHelper.create_image(deck)
+            test_key_image = PILHelper.to_native_format(deck, test_key_image)
+
+            deck.set_key_image(0, None)
+            deck.set_key_image(0, test_key_image)
 
         deck.close()
 
 
 def test_key_pattern(deck):
+    if not deck.is_visual():
+        return
     test_key_image = PILHelper.create_image(deck)
 
     draw = ImageDraw.Draw(test_key_image)


### PR DESCRIPTION
This add support for the Stream Deck Pedal, which behaves essentially like the XL except with no image support.

What's exciting is that we get key down and up notifications, just like the real Stream Decks:


```
python src/example_pedal.py
Found 2 Stream Deck(s).

Opened 'Stream Deck Pedal' device (serial number: 'FL09L1XXXXXX', fw: '2.0.2.8')
Deck DevSrvsID:4295155749 Key 0 = down
Deck DevSrvsID:4295155749 Key 0 = up
Deck DevSrvsID:4295155749 Key 1 = down
Deck DevSrvsID:4295155749 Key 2 = down
Deck DevSrvsID:4295155749 Key 2 = up
Deck DevSrvsID:4295155749 Key 1 = up
Deck DevSrvsID:4295155749 Key 0 = down
Deck DevSrvsID:4295155749 Key 2 = down
Deck DevSrvsID:4295155749 Key 1 = down
Deck DevSrvsID:4295155749 Key 0 = up
Deck DevSrvsID:4295155749 Key 1 = up
Deck DevSrvsID:4295155749 Key 2 = up
```

In my opinion, this is even more important for the foot pedal, as it could be used to build more interesting integrations (like doing something continuously while your foot is down), and not something currently supported by the official software.

The new implementation class is mostly a cut-down `StreamDeckXL`. I also added a `is_visual()` function to the `StreamDeck`base class so that the existing example won't attempt to open the pedal, and added a new example file for it.