### PR TITLE
feat: enable relative path dll loading for windows

### DIFF
--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
+++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
@@ -109,7 +109,7 @@ class LibUSBHIDAPI(Transport):
             """
 
             search_library_names = {
-                "Windows": ["hidapi.dll", "libhidapi-0.dll"],
+                "Windows": ["hidapi.dll", "libhidapi-0.dll", "./hidapi.dll"],
                 "Linux": ["libhidapi-libusb.so", "libhidapi-libusb.so.0"],
                 "Darwin": ["libhidapi.dylib"],
             }


### PR DESCRIPTION
Hi,

Thanks for authoring this. It is incredibly cool to be able to use python to control a StreamDeck.

I've had issues on every platform I've used this for so far 😅 from [building hidapi dynlib on OSX](https://github.com/libusb/hidapi/issues/603) to getting windows to load hidapi.dll without placing in shared folders.

It's a fairly common Workaround for Windows apps to be able to override a system level DLL using one in their present directory. This enables that using this python library, without affecting the rest of the code.

If it works for you, great. If not, I won't be offended. I've tested using all the examples provided. Next up Linux 😅 

Thanks again 👋 