### PR TITLE
Handle exception when find_library fails

### DIFF
--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
+++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
@@ -57,7 +57,10 @@ class LibUSBHIDAPI(Transport):
                 # its default search paths. It requires the name of the library only (minus all
                 # path prefix and extension suffix).
                 library_name_no_extension = os.path.basename(os.path.splitext(lib_name)[0])
-                found_lib = ctypes.util.find_library(library_name_no_extension)
+                try:
+                    found_lib = ctypes.util.find_library(library_name_no_extension)
+                except:
+                    found_lib = None
 
                 # If we've running with a Homebrew installation, and find_library() didn't find the library in
                 # any of the default search paths, we'll look in Homebrew instead as a fallback.


### PR DESCRIPTION
ctypes.util.find_library() can except if libhidapi-usblib.a is installed. See abcminiuser/python-elgato-streamdeck#120

I don't consider this a resolution to the defect described in 120, but as gcc detection is complicated, there are other reasons this could fail and continuing will be valid. LoadLibrary() is the drop-dead point for library loading.