### PR TITLE
FreeBSD: use libhidapi.so

### DIFF
--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
+++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
@@ -154,6 +154,7 @@ class LibUSBHIDAPI(Transport):
                 "Windows": ["hidapi.dll", "libhidapi-0.dll", "./hidapi.dll"],
                 "Linux": ["libhidapi-libusb.so", "libhidapi-libusb.so.0"],
                 "Darwin": ["libhidapi.dylib"],
+                "FreeBSD": ["libhidapi.so"],
             }
 
             self.platform_name = platform.system()


### PR DESCRIPTION
This change enables the streamdeck python module work in FreeBSD, by using the libhidapi.so library.