### PR TITLE
Added Unions and Optionals to support python 3.9

### DIFF
--- a/src/StreamDeck/DeviceManager.py
+++ b/src/StreamDeck/DeviceManager.py
@@ -17,6 +17,7 @@ from .Transport import Transport
 from .Transport.Dummy import Dummy
 from .Transport.LibUSBHIDAPI import LibUSBHIDAPI
 from .ProductIDs import USBVendorIDs, USBProductIDs
+from typing import Union
 
 
 class ProbeError(Exception):
@@ -36,7 +37,7 @@ class DeviceManager:
     """
 
     @staticmethod
-    def _get_transport(transport: str | None):
+    def _get_transport(transport: Union[str, None]):
         """
         Creates a new HID transport instance from the given transport back-end
         name. If no specific transport is supplied, an attempt to find an
@@ -79,7 +80,7 @@ class DeviceManager:
 
             raise ProbeError("Probe failed to find any functional HID backend.", probe_errors)
 
-    def __init__(self, transport: str | None = None):
+    def __init__(self, transport: Union[str, None] = None):
         """
         Creates a new StreamDeck DeviceManager, used to detect attached StreamDeck devices.
 

--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -10,7 +10,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
-from typing import Any, Iterable, TypeVar
+from typing import Any, Iterable, TypeVar, Optional, Union
 
 from ..Transport.Transport import Transport, TransportError
 
@@ -81,9 +81,9 @@ class StreamDeck(ABC):
     DECK_TOUCH = False
 
     _Self = TypeVar('_Self', bound='StreamDeck')
-    KeyCallback = Callable[[_Self, int, bool], None] | None
-    DialCallback = Callable[[_Self, int, DialEventType, bool], None] | None
-    TouchScreenCallback = Callable[[_Self, TouchscreenEventType, Any], None] | None
+    KeyCallback = Optional[Callable[[_Self, int, bool], None]]
+    DialCallback = Optional[Callable[[_Self, int, DialEventType, bool], None]]
+    TouchScreenCallback = Optional[Callable[[_Self, TouchscreenEventType, Any], None]]
 
     def __init__(self, device: Transport.Device):
         self.device: Transport.Device = device
@@ -598,7 +598,7 @@ class StreamDeck(ABC):
         pass
 
     @abstractmethod
-    def set_brightness(self, percent: int | float) -> None:
+    def set_brightness(self, percent: Union[int, float]) -> None:
         """
         Sets the global screen brightness of the StreamDeck, across all the
         physical buttons.


### PR DESCRIPTION
Issues with `int | None` typing on python 3.9, swapped out the syntax to use Union and Optional for better support.