### PR TITLE
fix(transport): return None from Dummy.read() when no data available

### DIFF
--- a/src/StreamDeck/Transport/Dummy.py
+++ b/src/StreamDeck/Transport/Dummy.py
@@ -78,7 +78,7 @@ class Dummy(Transport):
                 raise TransportError("Deck read while deck not open.")
 
             logging.info("Deck report read (length %s)", length)
-            return bytearray(length)
+            return None
 
     @staticmethod
     def probe():


### PR DESCRIPTION
## Summary

Fixes 100% CPU usage when using the Dummy transport for testing.

## Problem

The Dummy transport's `read()` method was returning `bytearray(length)` instead of `None` when no data is available. This causes the StreamDeck polling loop to never sleep, resulting in 100% CPU usage.

## Solution

Changed `Dummy.Device.read()` to return `None` when no data is available, matching the behavior of `LibUSBHIDAPI` which returns `None` when `hid_read()` returns 0.

## Verification

Run this script to verify the fix (watch CPU usage - without the fix it spins at 100%):

```python
#!/usr/bin/env python3
import time

from StreamDeck.DeviceManager import DeviceManager

manager = DeviceManager(transport="dummy")
deck = manager.enumerate()[0]
deck.open()

start = time.time()
count = 0
while time.time() - start < 5:
    deck.read(timeout_ms=100)
    count += 1

deck.close()
print(f"Completed {count} iterations in 5 seconds")
```